### PR TITLE
imr: make the transition to overloaded size_of context functions

### DIFF
--- a/data/cell.hh
+++ b/data/cell.hh
@@ -53,35 +53,33 @@ struct cell {
 
 
     struct tags {
-        class cell;
-        class atomic_cell;
-        class collection;
+        class cell {};
+        class atomic_cell {};
+        class collection {};
 
-        class flags;
-        class live;
-        class expiring;
-        class counter_update;
-        class external_data;
+        class flags {};
+        class live {};
+        class expiring {};
+        class counter_update {};
+        class external_data {};
 
-        class ttl;
-        class expiry;
-        class empty;
-        class timestamp;
-        class value;
-        class dead;
-        class counter_update;
-        class fixed_value;
-        class variable_value;
-        class value_size;
-        class value_data;
-        class pointer;
-        class data;
-        class external_data;
+        class ttl {};
+        class expiry {};
+        class empty {};
+        class timestamp {};
+        class value {};
+        class dead {};
+        class fixed_value {};
+        class variable_value {};
+        class value_size {};
+        class value_data {};
+        class pointer {};
+        class data {};
 
-        class chunk_back_pointer;
-        class chunk_next;
-        class chunk_data;
-        class last_chunk_size;
+        class chunk_back_pointer {};
+        class chunk_next {};
+        class chunk_data {};
+        class last_chunk_size {};
     };
 
     using flags = imr::flags<
@@ -261,7 +259,7 @@ struct cell {
                 }
             }
             template<typename Tag>
-            size_t size_of() const noexcept {
+            size_t size_of(Tag) const noexcept {
                 return _value_size;
             }
             template<typename Tag, typename... Args>
@@ -354,7 +352,7 @@ struct cell {
         explicit constexpr chunk_context(const uint8_t*) noexcept { }
 
         template<typename Tag>
-        static constexpr size_t size_of() noexcept {
+        static constexpr size_t size_of(Tag) noexcept {
             return cell::effective_external_chunk_length;
         }
         template<typename Tag, typename... Args>
@@ -372,7 +370,7 @@ struct cell {
         { }
 
         template<typename Tag>
-        size_t size_of() const noexcept {
+        size_t size_of(Tag) const noexcept {
             return _size;
         }
 
@@ -584,7 +582,7 @@ public:
     auto active_alternative_of() const noexcept;
 
     template<typename Tag>
-    size_t size_of() const noexcept;
+    size_t size_of(Tag) const noexcept;
 
     template<typename Tag>
     auto context_for(const uint8_t*) const noexcept {
@@ -631,7 +629,7 @@ public:
     }
 
     template<typename Tag>
-    size_t size_of() const noexcept;
+    size_t size_of(Tag) const noexcept;
 
     template<typename Tag>
     auto context_for(const uint8_t*) const noexcept {
@@ -669,7 +667,7 @@ inline auto cell::context::active_alternative_of<cell::tags::value>() const noex
 }
 
 template<>
-inline size_t cell::context::size_of<cell::tags::fixed_value>() const noexcept {
+inline size_t cell::context::size_of<cell::tags::fixed_value>(cell::tags::fixed_value) const noexcept {
     return _flags.get<tags::empty>() ? 0 : _type.value_size();
 }
 

--- a/data/cell.hh
+++ b/data/cell.hh
@@ -258,10 +258,10 @@ struct cell {
                     return data_variant::index_for<tags::data>();
                 }
             }
-            template<typename Tag>
-            size_t size_of(Tag) const noexcept {
+            size_t size_of(tags::data) const noexcept {
                 return _value_size;
             }
+
             template<typename Tag, typename... Args>
             auto context_for(Args&&...) const noexcept {
                 return *this;
@@ -351,8 +351,7 @@ struct cell {
     struct chunk_context {
         explicit constexpr chunk_context(const uint8_t*) noexcept { }
 
-        template<typename Tag>
-        static constexpr size_t size_of(Tag) noexcept {
+        static constexpr size_t size_of(tags::chunk_data) noexcept {
             return cell::effective_external_chunk_length;
         }
         template<typename Tag, typename... Args>
@@ -369,8 +368,7 @@ struct cell {
                 : _size(external_last_chunk::get_member<tags::last_chunk_size>(ptr).load())
         { }
 
-        template<typename Tag>
-        size_t size_of(Tag) const noexcept {
+        size_t size_of(tags::chunk_data) const noexcept {
             return _size;
         }
 
@@ -582,9 +580,6 @@ public:
     auto active_alternative_of() const noexcept;
 
     template<typename Tag>
-    size_t size_of(Tag) const noexcept;
-
-    template<typename Tag>
     auto context_for(const uint8_t*) const noexcept {
         return *this;
     }
@@ -628,8 +623,9 @@ public:
         return minimal_context::active_alternative_of<Tag>();
     }
 
-    template<typename Tag>
-    size_t size_of(Tag) const noexcept;
+    size_t size_of(cell::tags::fixed_value) const noexcept {
+        return _flags.get<tags::empty>() ? 0 : _type.value_size();
+    }
 
     template<typename Tag>
     auto context_for(const uint8_t*) const noexcept {
@@ -664,11 +660,6 @@ inline auto cell::context::active_alternative_of<cell::tags::value>() const noex
     } else {
         return cell::value_variant::index_for<tags::dead>();
     }
-}
-
-template<>
-inline size_t cell::context::size_of<cell::tags::fixed_value>(cell::tags::fixed_value) const noexcept {
-    return _flags.get<tags::empty>() ? 0 : _type.value_size();
 }
 
 /// Atomic cell view

--- a/imr/fundamental.hh
+++ b/imr/fundamental.hh
@@ -223,8 +223,8 @@ public:
 };
 
 template<typename Context, typename Tag>
-concept HasSizeof = requires(const Context& ctx) {
-    { ctx.template size_of<Tag>() } noexcept -> std::same_as<size_t>;
+concept HasSizeof = requires(const Context& ctx, Tag t) {
+    { ctx.size_of(t) } noexcept -> std::same_as<size_t>;
 };
 
 /// Buffer

--- a/test/manual/imr_test.cc
+++ b/test/manual/imr_test.cc
@@ -42,10 +42,10 @@
 
 static constexpr auto random_test_iteration_count = 20;
 
-class A;
-class B;
-class C;
-class D;
+class A {};
+class B {};
+class C {};
+class D {};
 
 BOOST_AUTO_TEST_SUITE(fundamental);
 
@@ -152,11 +152,11 @@ public:
     explicit test_buffer_context(size_t sz) : _size(sz) { }
 
     template<typename Tag>
-    size_t size_of() const noexcept;
+    size_t size_of(Tag) const noexcept;
 };
 
 template<>
-size_t test_buffer_context::size_of<A>() const noexcept {
+size_t test_buffer_context::size_of<A>(A) const noexcept {
     return _size;
 }
 
@@ -248,7 +248,7 @@ struct test_variant_context {
     unsigned _alternative_idx;
 public:
     template<typename Tag>
-    size_t size_of() const noexcept;
+    size_t size_of(Tag) const noexcept;
 
     template<typename Tag>
     auto active_alternative_of() const noexcept;
@@ -258,7 +258,7 @@ public:
 };
 
 template<>
-size_t test_variant_context::size_of<C>() const noexcept {
+size_t test_variant_context::size_of<C>(C) const noexcept {
     return data_size;
 }
 
@@ -398,7 +398,7 @@ public:
     bool is_present() const noexcept;
 
     template<typename Tag>
-    size_t size_of() const noexcept;
+    size_t size_of(Tag) const noexcept;
 
     template<typename Tag, typename... Args>
     decltype(auto) context_for(Args&&...) const noexcept { return *this; }
@@ -410,7 +410,7 @@ bool test_structure_context::is_present<B>() const noexcept {
 }
 
 template<>
-size_t test_structure_context::size_of<C>() const noexcept {
+size_t test_structure_context::size_of<C>(C) const noexcept {
     return _c_size_of;
 }
 
@@ -746,7 +746,7 @@ struct structue_context {
     }
     
     template<typename Tag>
-    size_t size_of() const noexcept {
+    size_t size_of(Tag) const noexcept {
         return _size;
     }
 
@@ -764,7 +764,7 @@ struct nested_structue_context {
     }
     
     template<typename Tag>
-    size_t size_of() const noexcept {
+    size_t size_of(Tag) const noexcept {
         return _size;
     }
 

--- a/test/manual/imr_test.cc
+++ b/test/manual/imr_test.cc
@@ -151,14 +151,10 @@ class test_buffer_context {
 public:
     explicit test_buffer_context(size_t sz) : _size(sz) { }
 
-    template<typename Tag>
-    size_t size_of(Tag) const noexcept;
+    size_t size_of(A) const noexcept {
+        return _size;
+    }
 };
-
-template<>
-size_t test_buffer_context::size_of<A>(A) const noexcept {
-    return _size;
-}
 
 BOOST_AUTO_TEST_CASE(test_buffer) {
     using buffer_type = imr::buffer<A>;
@@ -247,8 +243,9 @@ using variant_type = imr::variant<A,
 struct test_variant_context {
     unsigned _alternative_idx;
 public:
-    template<typename Tag>
-    size_t size_of(Tag) const noexcept;
+    size_t size_of(C) const noexcept {
+        return data_size;
+    }
 
     template<typename Tag>
     auto active_alternative_of() const noexcept;
@@ -256,11 +253,6 @@ public:
     template<typename Tag, typename... Args>
     decltype(auto) context_for(Args&&...) const noexcept { return *this; }
 };
-
-template<>
-size_t test_variant_context::size_of<C>(C) const noexcept {
-    return data_size;
-}
 
 template<>
 auto test_variant_context::active_alternative_of<A>() const noexcept {
@@ -397,8 +389,9 @@ public:
     template<typename Tag>
     bool is_present() const noexcept;
 
-    template<typename Tag>
-    size_t size_of(Tag) const noexcept;
+    size_t size_of(C) const noexcept {
+        return _c_size_of;
+    }
 
     template<typename Tag, typename... Args>
     decltype(auto) context_for(Args&&...) const noexcept { return *this; }
@@ -407,11 +400,6 @@ public:
 template<>
 bool test_structure_context::is_present<B>() const noexcept {
     return _b_is_present;
-}
-
-template<>
-size_t test_structure_context::size_of<C>(C) const noexcept {
-    return _c_size_of;
 }
 
 BOOST_AUTO_TEST_CASE(test_structure_with_context) {
@@ -745,8 +733,7 @@ struct structue_context {
         BOOST_CHECK_EQUAL(_size, 4);
     }
     
-    template<typename Tag>
-    size_t size_of(Tag) const noexcept {
+    size_t size_of(A) const noexcept {
         return _size;
     }
 
@@ -763,8 +750,7 @@ struct nested_structue_context {
         BOOST_CHECK_NE(_size, 0);
     }
     
-    template<typename Tag>
-    size_t size_of(Tag) const noexcept {
+    size_t size_of(B) const noexcept {
         return _size;
     }
 


### PR DESCRIPTION
This mini set, makes the transition to overloaded size_of functions in context instead of templated ones.
This patchset does this in 2 stages:
1. First the transition is made trivially - we keep the templated implementations but changing the constrainet to an overloaded one. This means that the template implementation in the contexts generates the overloaded functions.
2. We drop the templated implementations and only implement the size_of overloaded versions that are actually needed. This adds the safety that was intended in the first place, whenever a size_of for a specific tag is not implemented the compilation will fail with constraint not met compilation error instead of just generating a default version using the template. 