### PR TITLE
RFC: use concrete types for writers

### DIFF
--- a/imr/compound.hh
+++ b/imr/compound.hh
@@ -475,6 +475,12 @@ struct structure_serializer<Continuation, variant_member<Tag, Types...>, Members
 // Represents a compound type.
 template<typename... Members>
 struct structure {
+    template <typename Continuation>
+    using sizer = internal::structure_sizer<Continuation, Members...>;
+
+    template <typename Continuation>
+    using serializer = internal::structure_serializer<Continuation, Members...>;
+
     template<::mutable_view is_mutable>
     class basic_view {
         using pointer_type = std::conditional_t<is_mutable == ::mutable_view::no,
@@ -537,13 +543,13 @@ public:
     }
 
     template<typename Continuation = no_op_continuation>
-    static internal::structure_sizer<Continuation, Members...> get_sizer(Continuation cont = no_op_continuation()) {
-        return internal::structure_sizer<Continuation, Members...>(0, std::move(cont));
+    static sizer<Continuation> get_sizer(Continuation cont = no_op_continuation()) {
+        return sizer<Continuation>(0, std::move(cont));
     }
 
     template<typename Continuation = no_op_continuation>
-    static internal::structure_serializer<Continuation, Members...> get_serializer(uint8_t* out, Continuation cont = no_op_continuation()) {
-        return internal::structure_serializer<Continuation, Members...>(out, std::move(cont));
+    static serializer<Continuation> get_serializer(uint8_t* out, Continuation cont = no_op_continuation()) {
+        return serializer<Continuation>(out, std::move(cont));
     }
 
     template<typename Writer, typename... Args>

--- a/imr/compound.hh
+++ b/imr/compound.hh
@@ -31,6 +31,11 @@
 
 namespace imr {
 
+namespace alloc {
+class object_allocator_sizer;
+class object_allocator_serializer;
+};
+
 /// Optionally present object
 ///
 /// Represents a value that may be not present. Information whether or not
@@ -480,6 +485,21 @@ struct structure {
 
     template <typename Continuation>
     using serializer = internal::structure_serializer<Continuation, Members...>;
+
+    template <typename ActualWriter>
+    struct writer {
+        ActualWriter _writer;
+
+        template <typename Continuation>
+        auto operator()(sizer<Continuation> serializer, alloc::object_allocator_sizer& allocs) {
+            return _writer(serializer, allocs);
+        }
+
+        template <typename Continuation>
+        auto operator()(serializer<Continuation> serializer, alloc::object_allocator_serializer& allocs) {
+            return _writer(serializer, allocs);
+        }
+    };
 
     template<::mutable_view is_mutable>
     class basic_view {


### PR DESCRIPTION
This series intends to improve the readability and understandability of the very complex write path of imr objects by introducing a `structure::writer<>` wrapper type which writer factories can return instead of auto. This wrapper also has a much more narrow interface, serving as executable documentation on what the parameters can be.