### PR TITLE
imr: serializers: specialize structure_sizer, structure_serializer empty cases

### DIFF
--- a/imr/compound.hh
+++ b/imr/compound.hh
@@ -280,7 +280,11 @@ using variant_member = member<Tag, variant<Tag, Types...>>;
 namespace internal {
 
 template<typename Continuation, typename... Members>
-class structure_sizer : Continuation {
+class structure_sizer;
+
+// Special case: no members
+template<typename Continuation>
+class structure_sizer<Continuation> : Continuation {
     size_t _size;
 public:
     explicit structure_sizer(size_t size, Continuation&& cont) noexcept
@@ -378,7 +382,11 @@ struct structure_sizer<Continuation, variant_member<Tag, Types...>, Members...>
 };
 
 template<typename Continuation, typename... Members>
-class structure_serializer : Continuation {
+class structure_serializer;
+
+// Special case: no members
+template<typename Continuation>
+class structure_serializer<Continuation> : Continuation {
     uint8_t* _out;
 public:
     explicit structure_serializer(uint8_t* out, Continuation&& cont) noexcept


### PR DESCRIPTION
structure_sizer and structure_serializer are both recursive templates.
Apart from the Continuation template parameter, they both accept
a Members template parameter which they process one by one by matching
it against a <typename Member, typename... Members> pattern for the
non-empty case.

The empty case is matched by the non-specialized case. However, this
is confusing, since it looks like the general case is ignoring its
Members... parameter. In fact it is correct since the only case where
the general case matches is when that parameter is empty.

To reduce confusion, eliminate the general case and instead provide
a specialization for the empty case.