### PR TITLE
Writer types/v2

### DIFF
--- a/data/cell.hh
+++ b/data/cell.hh
@@ -537,7 +537,9 @@ public:
     ///
     /// \arg ptr needs to remain valid as long as the writer is in use.
     /// \returns an instance of cell::structure::writer.
-    static structure::writer<collection_writer<copy_writer>> copy_fn(const type_info& ti, const uint8_t* ptr);
+    static structure::writer<copy_writer> copy_fn(const type_info& ti, const uint8_t* ptr) noexcept {
+        return structure::writer<copy_writer>(copy_writer(ti, ptr));
+    }
 
     /// Make a writer for a collection
     ///

--- a/imr/alloc.hh
+++ b/imr/alloc.hh
@@ -22,99 +22,12 @@
 #pragma once
 
 #include "utils/chunked_vector.hh"
-#include "utils/logalloc.hh"
+#include "utils/allocation_strategy.hh"
 
 #include "imr/core.hh"
-#include "imr/methods.hh"
 
 namespace imr {
 namespace alloc {
-
-static const struct no_context_factory_t {
-    static no_context_t create(const void*) noexcept { return no_context; }
-} no_context_factory;
-
-/// Deserialisation context factory
-///
-/// Deserialisation contexts provide the IMR code with additional information
-/// needed to deserialise an IMR object. Often the sources of that information
-/// are both the object itself as well as some external state shared by multiple
-/// IMR objects of the same type.
-/// `context_factory` is a helper class for creating contexts it keeps the
-/// shared state (e.g. per-schema information) and when given a pointer to a
-/// IMR object creates a deserialisation context for it.
-template<typename Context, typename... State>
-class context_factory {
-    std::tuple<State...> _state;
-private:
-    template<size_t... Index>
-    Context create(const uint8_t* ptr, std::index_sequence<Index...>) const noexcept {
-        return Context(ptr, std::get<Index>(_state)...);
-    }
-public:
-    template<typename... Args>
-    context_factory(Args&&... args) : _state(std::forward<Args>(args)...) { }
-
-    context_factory(context_factory&) = default;
-    context_factory(const context_factory&) = default;
-    context_factory(context_factory&&) = default;
-
-    Context create(const uint8_t* ptr) const noexcept {
-        return create(ptr, std::index_sequence_for<State...>());
-    }
-};
-
-template<typename T>
-concept ContextFactory = requires(const T factory, const uint8_t* ptr) {
-    { factory.create(ptr) } noexcept;
-};
-
-static_assert(ContextFactory<no_context_factory_t>,
-              "no_context_factory_t has to meet ContextFactory constraints");
-
-/// LSA migrator for IMR objects
-///
-/// IMR objects may own memory and therefore moving and destroying them may
-/// be non-trivial. This class implements an LSA migrator for an IMR objects
-/// of type `Structure`. The deserialisation context needed to invoke the mover
-/// is going to be created by the provided context factory `CtxFactory`.
-template<typename Structure, typename CtxFactory>
-requires ContextFactory<CtxFactory>
-class lsa_migrate_fn final : public migrate_fn_type, CtxFactory {
-public:
-    using structure = Structure;
-
-    explicit lsa_migrate_fn(CtxFactory context_factory)
-        : migrate_fn_type(1)
-        , CtxFactory(std::move(context_factory))
-    { }
-
-    lsa_migrate_fn(lsa_migrate_fn&&) = delete;
-    lsa_migrate_fn(const lsa_migrate_fn&) = delete;
-
-    lsa_migrate_fn& operator=(lsa_migrate_fn&&) = delete;
-    lsa_migrate_fn& operator=(const lsa_migrate_fn&) = delete;
-
-    virtual void migrate(void* src_ptr, void* dst_ptr, size_t size) const noexcept override {
-        std::memcpy(dst_ptr, src_ptr, size);
-        auto dst = static_cast<uint8_t*>(dst_ptr);
-        methods::move<Structure>(dst, CtxFactory::create(dst));
-    }
-
-    virtual size_t size(const void* obj_ptr) const noexcept override {
-        auto ptr = static_cast<const uint8_t*>(obj_ptr);
-        return Structure::serialized_object_size(ptr, CtxFactory::create(ptr));
-    }
-};
-
-// LSA migrator for objects which mover doesn't require a deserialisation context
-template<typename Structure>
-struct default_lsa_migrate_fn {
-    static lsa_migrate_fn<Structure, no_context_factory_t> migrate_fn;
-};
-
-template<typename Structure>
-lsa_migrate_fn<Structure, no_context_factory_t> default_lsa_migrate_fn<Structure>::migrate_fn(no_context_factory);
 
 /// IMR object allocator
 ///

--- a/imr/compound.hh
+++ b/imr/compound.hh
@@ -483,6 +483,12 @@ struct structure_serializer<Continuation, variant_member<Tag, Types...>, Members
 // Represents a compound type.
 template<typename... Members>
 struct structure {
+    template <typename Continuation>
+    using sizer = internal::structure_sizer<Continuation, Members...>;
+
+    template <typename Continuation>
+    using serializer = internal::structure_serializer<Continuation, Members...>;
+
     template<::mutable_view is_mutable>
     class basic_view {
         using pointer_type = std::conditional_t<is_mutable == ::mutable_view::no,
@@ -545,13 +551,13 @@ public:
     }
 
     template<typename Continuation = no_op_continuation>
-    static internal::structure_sizer<Continuation, Members...> get_sizer(Continuation cont = no_op_continuation()) {
-        return internal::structure_sizer<Continuation, Members...>(0, std::move(cont));
+    static sizer<Continuation> get_sizer(Continuation cont = no_op_continuation()) {
+        return sizer<Continuation>(0, std::move(cont));
     }
 
     template<typename Continuation = no_op_continuation>
-    static internal::structure_serializer<Continuation, Members...> get_serializer(uint8_t* out, Continuation cont = no_op_continuation()) {
-        return internal::structure_serializer<Continuation, Members...>(out, std::move(cont));
+    static serializer<Continuation> get_serializer(uint8_t* out, Continuation cont = no_op_continuation()) {
+        return serializer<Continuation>(out, std::move(cont));
     }
 
     template<typename Writer, typename... Args>

--- a/imr/logalloc.hh
+++ b/imr/logalloc.hh
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "utils/logalloc.hh"
+
+#include "imr/core.hh"
+#include "imr/methods.hh"
+
+namespace imr {
+namespace alloc {
+
+static const struct no_context_factory_t {
+    static no_context_t create(const void*) noexcept { return no_context; }
+} no_context_factory;
+
+/// Deserialisation context factory
+///
+/// Deserialisation contexts provide the IMR code with additional information
+/// needed to deserialise an IMR object. Often the sources of that information
+/// are both the object itself as well as some external state shared by multiple
+/// IMR objects of the same type.
+/// `context_factory` is a helper class for creating contexts it keeps the
+/// shared state (e.g. per-schema information) and when given a pointer to a
+/// IMR object creates a deserialisation context for it.
+template<typename Context, typename... State>
+class context_factory {
+    std::tuple<State...> _state;
+private:
+    template<size_t... Index>
+    Context create(const uint8_t* ptr, std::index_sequence<Index...>) const noexcept {
+        return Context(ptr, std::get<Index>(_state)...);
+    }
+public:
+    template<typename... Args>
+    context_factory(Args&&... args) : _state(std::forward<Args>(args)...) { }
+
+    context_factory(context_factory&) = default;
+    context_factory(const context_factory&) = default;
+    context_factory(context_factory&&) = default;
+
+    Context create(const uint8_t* ptr) const noexcept {
+        return create(ptr, std::index_sequence_for<State...>());
+    }
+};
+
+template<typename T>
+concept ContextFactory = requires(const T factory, const uint8_t* ptr) {
+    { factory.create(ptr) } noexcept;
+};
+
+static_assert(ContextFactory<no_context_factory_t>,
+              "no_context_factory_t has to meet ContextFactory constraints");
+
+/// LSA migrator for IMR objects
+///
+/// IMR objects may own memory and therefore moving and destroying them may
+/// be non-trivial. This class implements an LSA migrator for an IMR objects
+/// of type `Structure`. The deserialisation context needed to invoke the mover
+/// is going to be created by the provided context factory `CtxFactory`.
+template<typename Structure, typename CtxFactory>
+requires ContextFactory<CtxFactory>
+class lsa_migrate_fn final : public migrate_fn_type, CtxFactory {
+public:
+    using structure = Structure;
+
+    explicit lsa_migrate_fn(CtxFactory context_factory)
+        : migrate_fn_type(1)
+        , CtxFactory(std::move(context_factory))
+    { }
+
+    lsa_migrate_fn(lsa_migrate_fn&&) = delete;
+    lsa_migrate_fn(const lsa_migrate_fn&) = delete;
+
+    lsa_migrate_fn& operator=(lsa_migrate_fn&&) = delete;
+    lsa_migrate_fn& operator=(const lsa_migrate_fn&) = delete;
+
+    virtual void migrate(void* src_ptr, void* dst_ptr, size_t size) const noexcept override {
+        std::memcpy(dst_ptr, src_ptr, size);
+        auto dst = static_cast<uint8_t*>(dst_ptr);
+        methods::move<Structure>(dst, CtxFactory::create(dst));
+    }
+
+    virtual size_t size(const void* obj_ptr) const noexcept override {
+        auto ptr = static_cast<const uint8_t*>(obj_ptr);
+        return Structure::serialized_object_size(ptr, CtxFactory::create(ptr));
+    }
+};
+
+// LSA migrator for objects which mover doesn't require a deserialisation context
+template<typename Structure>
+struct default_lsa_migrate_fn {
+    static lsa_migrate_fn<Structure, no_context_factory_t> migrate_fn;
+};
+
+template<typename Structure>
+lsa_migrate_fn<Structure, no_context_factory_t> default_lsa_migrate_fn<Structure>::migrate_fn(no_context_factory);
+
+}
+}

--- a/imr/utils.hh
+++ b/imr/utils.hh
@@ -164,16 +164,14 @@ public:
 
     /// Create an IMR objects
     template<typename Writer, typename MigrateFn>
-    requires WriterAllocator<Writer, Structure>
-    static object make(Writer&& object_writer,
+    static object make(typename Structure::writer<Writer>&& object_writer,
                        MigrateFn* migrate = &imr::alloc::default_lsa_migrate_fn<structure>::migrate_fn) {
         static_assert(std::is_same_v<typename MigrateFn::structure, structure>);
-        return do_make(std::forward<Writer>(object_writer), migrate);
+        return do_make(std::forward<typename Structure::writer<Writer>>(object_writer), migrate);
     }
 private:
     template<typename Writer>
-    requires WriterAllocator<Writer, Structure>
-    static object do_make(Writer&& object_writer, allocation_strategy::migrate_fn migrate) {
+    static object do_make(typename Structure::writer<Writer>&& object_writer, allocation_strategy::migrate_fn migrate) {
         struct alloc_deleter {
             size_t _size;
 

--- a/imr/utils.hh
+++ b/imr/utils.hh
@@ -25,6 +25,7 @@
 
 #include "imr/core.hh"
 #include "imr/alloc.hh"
+#include "imr/logalloc.hh"
 #include "imr/concepts.hh"
 
 namespace imr {

--- a/test/manual/imr_test.cc
+++ b/test/manual/imr_test.cc
@@ -799,7 +799,7 @@ BOOST_AUTO_TEST_CASE(test_object_exception_safety) {
     using lsa_migrator_fn_for_nested_structure = imr::alloc::lsa_migrate_fn<nested_structure, context_factory_for_nested_structure>;
     auto migrator_for_nested_structure = lsa_migrator_fn_for_nested_structure(context_factory_for_nested_structure());
 
-    auto writer_fn = [&] (auto serializer, auto& allocator) {
+    auto writer_fn = [&] (auto serializer, auto allocator) {
         return serializer
             .serialize(4)
             .serialize(allocator.template allocate<nested_structure>(
@@ -832,7 +832,7 @@ BOOST_AUTO_TEST_CASE(test_object_exception_safety) {
         while (true) {
             allocator.fail_after(fail_offset++);
             try {
-                imr::utils::object<structure>::make(writer_fn, &migrator_for_structure);
+                imr::utils::object<structure>::make(structure::writer<decltype(writer_fn)>(writer_fn), &migrator_for_structure);
             } catch (const std::bad_alloc&) {
                 BOOST_CHECK_EQUAL(reg.occupancy().used_space(), 0);
                 continue;


### PR DESCRIPTION
This series intends to improve the readability and understandability of the very complex write path of imr objects by introducing a structure::writer<> wrapper type which writer factories can return instead of auto. This wrapper also has a much more narrow interface, serving as executable documentation on what the parameters can be.

New in v2:
* Don't forward declare the allocators in `imr/compound.hh`, remove dependency between `imr/compound.hh` and `imr/alloc.hh` and include it instead.
* Migrate all writers in cell.
* Make usage of `imr::structure::writer` wrapper mandatory by requiring it in `imr::object::make()`.
* Document `imr::structure::writer`.

Tests: unit(dev)