### PR TITLE
types: compare(): compare_maps(): work with fragmented buffers

### DIFF
--- a/types.cc
+++ b/types.cc
@@ -643,6 +643,14 @@ size_t collection_value_len(cql_serialization_format sf) {
     return sizeof(uint16_t);
 }
 
+template <FragmentRange Range>
+int read_collection_size(utils::linearizing_input_stream<Range>& in, cql_serialization_format sf) {
+    if (sf.using_32_bits_for_collections()) {
+        return in.template read_trivial<int32_t>();
+    } else {
+        return in.template read_trivial<uint16_t>();
+    }
+}
 
 int read_collection_size(bytes_view& in, cql_serialization_format sf) {
     if (sf.using_32_bits_for_collections()) {
@@ -658,6 +666,12 @@ void write_collection_size(bytes::iterator& out, int size, cql_serialization_for
     } else {
         serialize_int16(out, uint16_t(size));
     }
+}
+
+template <FragmentRange Range>
+bytes_view read_collection_value(utils::linearizing_input_stream<Range>& in, cql_serialization_format sf) {
+    auto size = sf.using_32_bits_for_collections() ? in.template read_trivial<int32_t>() : in.template read_trivial<uint16_t>();
+    return in.read(size);
 }
 
 bytes_view read_collection_value(bytes_view& in, cql_serialization_format sf) {

--- a/types.cc
+++ b/types.cc
@@ -1015,8 +1015,8 @@ map_type_impl::is_value_compatible_with_frozen(const collection_type_impl& previ
             && _values->is_value_compatible_with(*p->_values);
 }
 
-int32_t
-map_type_impl::compare_maps(data_type keys, data_type values, bytes_view o1, bytes_view o2) {
+static int32_t
+compare_maps(data_type keys, data_type values, bytes_view o1, bytes_view o2) {
     if (o1.empty()) {
         return o2.empty() ? 0 : -1;
     } else if (o2.empty()) {
@@ -2041,7 +2041,7 @@ struct compare_visitor {
                 [&] (bytes_view o1, bytes_view o2) { return l.get_elements_type()->compare(o1, o2); });
     }
     int32_t operator()(const map_type_impl& m) {
-        return map_type_impl::compare_maps(m.get_keys_type(), m.get_values_type(), v1, v2);
+        return compare_maps(m.get_keys_type(), m.get_values_type(), v1, v2);
     }
     int32_t operator()(const uuid_type_impl&) {
         if (v1.size() < 16) {

--- a/types.cc
+++ b/types.cc
@@ -1029,8 +1029,9 @@ map_type_impl::is_value_compatible_with_frozen(const collection_type_impl& previ
             && _values->is_value_compatible_with(*p->_values);
 }
 
+template <FragmentRange Range>
 static int32_t
-compare_maps(data_type keys, data_type values, bytes_view o1, bytes_view o2) {
+compare_maps(data_type keys, data_type values, utils::linearizing_input_stream<Range>& o1, utils::linearizing_input_stream<Range>& o2) {
     if (o1.empty()) {
         return o2.empty() ? 0 : -1;
     } else if (o2.empty()) {
@@ -2055,7 +2056,9 @@ struct compare_visitor {
                 [&] (bytes_view o1, bytes_view o2) { return l.get_elements_type()->compare(o1, o2); });
     }
     int32_t operator()(const map_type_impl& m) {
-        return compare_maps(m.get_keys_type(), m.get_values_type(), v1, v2);
+        auto in1 = utils::linearizing_input_stream(single_fragment_range(v1));
+        auto in2 = utils::linearizing_input_stream(single_fragment_range(v2));
+        return compare_maps(m.get_keys_type(), m.get_values_type(), in1, in2);
     }
     int32_t operator()(const uuid_type_impl&) {
         if (v1.size() < 16) {

--- a/types/map.hh
+++ b/types/map.hh
@@ -52,8 +52,6 @@ public:
     virtual data_type freeze() const override;
     virtual bool is_compatible_with_frozen(const collection_type_impl& previous) const override;
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const override;
-    static int32_t compare_maps(data_type keys_comparator, data_type values_comparator,
-                        bytes_view o1, bytes_view o2);
     using abstract_type::deserialize;
     virtual data_value deserialize(bytes_view v, cql_serialization_format sf) const override;
     static bytes serialize_partially_deserialized_form(const std::vector<std::pair<bytes_view, bytes_view>>& v,


### PR DESCRIPTION
Convert compare_maps() to work with fragmented buffers through `utils::linearizing_input_stream`. This is the first step in migrating the entire compare visitor to work with fragmented buffers.