### PR TITLE
Imr hackathon fixes

### DIFF
--- a/atomic_cell.cc
+++ b/atomic_cell.cc
@@ -131,7 +131,7 @@ bool atomic_cell_or_collection::equals(const abstract_type& type, const atomic_c
 
 size_t atomic_cell_or_collection::external_memory_usage(const abstract_type& t) const
 {
-    return _data.size();
+    return _data.external_memory_usage();
 }
 
 std::ostream&

--- a/atomic_cell.hh
+++ b/atomic_cell.hh
@@ -151,7 +151,7 @@ public:
         managed_bytes b(managed_bytes::initialized_later(), flags_size + timestamp_size + deletion_time_size);
         b[0] = 0;
         set_field(b, timestamp_offset, timestamp);
-        set_field(b, deletion_time_offset, deletion_time.time_since_epoch().count());
+        set_field(b, deletion_time_offset, static_cast<int32_t>(deletion_time.time_since_epoch().count()));
         return b;
     }
     template <FragmentRange Buffer>
@@ -177,8 +177,8 @@ public:
         managed_bytes b(managed_bytes::initialized_later(), value_offset + value.size_bytes());
         b[0] = EXPIRY_FLAG | LIVE_FLAG;
         set_field(b, timestamp_offset, timestamp);
-        set_field(b, expiry_offset, expiry.time_since_epoch().count());
-        set_field(b, ttl_offset, ttl.count());
+        set_field(b, expiry_offset, static_cast<int32_t>(expiry.time_since_epoch().count()));
+        set_field(b, ttl_offset, static_cast<int32_t>(ttl.count()));
         set_value(b, value_offset, value);
         return b;
     }

--- a/counters.hh
+++ b/counters.hh
@@ -294,12 +294,11 @@ protected:
 private:
     class shard_iterator : public std::iterator<std::input_iterator_tag, basic_counter_shard_view<is_mutable>> {
         managed_bytes_basic_view<is_mutable> _current;
-        size_t _pos = 0;
         basic_counter_shard_view<is_mutable> _current_view;
+        size_t _pos = 0;
     public:
-        shard_iterator() = default;
-        shard_iterator(managed_bytes_basic_view<is_mutable> v) noexcept
-            : _current(v), _current_view(_current) { }
+        shard_iterator(managed_bytes_basic_view<is_mutable> v, size_t offset) noexcept
+            : _current(v), _current_view(_current), _pos(offset) { }
 
         basic_counter_shard_view<is_mutable>& operator*() noexcept {
             return _current_view;
@@ -328,17 +327,14 @@ private:
             return it;
         }
         bool operator==(const shard_iterator& other) const noexcept {
-            return _current == other._current;
-        }
-        bool operator!=(const shard_iterator& other) const noexcept {
-            return !(*this == other);
+            return _pos == other._pos;
         }
     };
 public:
     boost::iterator_range<shard_iterator> shards() const {
         auto value = _cell.value();
-        auto begin = shard_iterator(value);
-        auto end = shard_iterator();
+        auto begin = shard_iterator(value, 0);
+        auto end = shard_iterator(value, value.size());
         return boost::make_iterator_range(begin, end);
     }
 

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -69,7 +69,8 @@ SEASTAR_TEST_CASE(test_counter_cell) {
         auto c1 = atomic_cell_or_collection(b1.build(0));
         
         atomic_cell_or_collection c2;
-      counter_cell_view::with_linearized(c1.as_atomic_cell(cdef), [&] (counter_cell_view cv) {
+      {
+        counter_cell_view cv(c1.as_atomic_cell(cdef));
         BOOST_REQUIRE_EQUAL(cv.total_value(), 1);
         verify_shard_order(cv);
 
@@ -77,18 +78,20 @@ SEASTAR_TEST_CASE(test_counter_cell) {
         b2.add_shard(counter_shard(*cv.get_shard(id[0])).update(2, 1));
         b2.add_shard(counter_shard(id[2], 1, 1));
         c2 = atomic_cell_or_collection(b2.build(0));
-    });
+      }
 
-      counter_cell_view::with_linearized(c2.as_atomic_cell(cdef), [&] (counter_cell_view cv) {
+      {
+        counter_cell_view cv(c2.as_atomic_cell(cdef));
         BOOST_REQUIRE_EQUAL(cv.total_value(), 8);
         verify_shard_order(cv);
-      });
+      }
 
         counter_cell_view::apply(cdef, c1, c2);
-      counter_cell_view::with_linearized(c1.as_atomic_cell(cdef), [&] (counter_cell_view cv) {
+      {
+        counter_cell_view cv(c1.as_atomic_cell(cdef));
         BOOST_REQUIRE_EQUAL(cv.total_value(), 4);
         verify_shard_order(cv);
-      });
+      }
     });
 }
 
@@ -101,10 +104,11 @@ SEASTAR_TEST_CASE(test_apply) {
             auto src = b.copy(*cdef.type);
             counter_cell_view::apply(cdef, dst, src);
 
-          counter_cell_view::with_linearized(dst.as_atomic_cell(cdef), [&] (counter_cell_view cv) {
+          {
+            counter_cell_view cv(dst.as_atomic_cell(cdef));
             BOOST_REQUIRE_EQUAL(cv.total_value(), value);
             BOOST_REQUIRE_EQUAL(cv.timestamp(), std::max(dst.as_atomic_cell(cdef).timestamp(), src.as_atomic_cell(cdef).timestamp()));
-          });
+          }
         };
         auto id = generate_ids(5);
 
@@ -240,17 +244,19 @@ SEASTAR_TEST_CASE(test_counter_mutations) {
         m.apply(m2);
         auto ac = get_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
-      counter_cell_view::with_linearized(ac, [&] (counter_cell_view ccv) {
+      {
+        counter_cell_view ccv(ac);
         BOOST_REQUIRE_EQUAL(ccv.total_value(), -102);
         verify_shard_order(ccv);
-      });
+      }
 
         ac = get_static_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
-      counter_cell_view::with_linearized(ac, [&] (counter_cell_view ccv) {
+      {
+        counter_cell_view ccv(ac);
         BOOST_REQUIRE_EQUAL(ccv.total_value(), 20);
         verify_shard_order(ccv);
-      });
+      }
 
         m.apply(m3);
         ac = get_counter_cell(m);
@@ -270,32 +276,36 @@ SEASTAR_TEST_CASE(test_counter_mutations) {
         m = mutation(s, m1.decorated_key(), m1.partition().difference(s, m2.partition()));
         ac = get_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
-      counter_cell_view::with_linearized(ac, [&] (counter_cell_view ccv) {
+      {
+        counter_cell_view ccv(ac);
         BOOST_REQUIRE_EQUAL(ccv.total_value(), 2);
         verify_shard_order(ccv);
-      });
+      }
 
         ac = get_static_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
-      counter_cell_view::with_linearized(ac, [&] (counter_cell_view ccv) {
+      {
+        counter_cell_view ccv(ac);
         BOOST_REQUIRE_EQUAL(ccv.total_value(), 11);
         verify_shard_order(ccv);
-      });
+      }
 
         m = mutation(s, m1.decorated_key(), m2.partition().difference(s, m1.partition()));
         ac = get_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
-      counter_cell_view::with_linearized(ac, [&] (counter_cell_view ccv) {
+      {
+        counter_cell_view ccv(ac);
         BOOST_REQUIRE_EQUAL(ccv.total_value(), -105);
         verify_shard_order(ccv);
-      });
+      }
 
         ac = get_static_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
-      counter_cell_view::with_linearized(ac, [&] (counter_cell_view ccv) {
+      {
+        counter_cell_view ccv(ac);
         BOOST_REQUIRE_EQUAL(ccv.total_value(), 9);
         verify_shard_order(ccv);
-      });
+      }
 
         m = mutation(s, m1.decorated_key(), m1.partition().difference(s, m3.partition()));
         BOOST_REQUIRE_EQUAL(m.partition().clustered_rows().calculate_size(), 0);
@@ -433,34 +443,38 @@ SEASTAR_TEST_CASE(test_transfer_updates_to_shards) {
 
         auto ac = get_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
-      counter_cell_view::with_linearized(ac, [&] (counter_cell_view ccv) {
+      {
+        counter_cell_view ccv(ac);
         BOOST_REQUIRE_EQUAL(ccv.total_value(), 5);
         verify_shard_order(ccv);
-      });
+      }
 
         ac = get_static_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
-      counter_cell_view::with_linearized(ac, [&] (counter_cell_view ccv) {
+      {
+        counter_cell_view ccv(ac);
         BOOST_REQUIRE_EQUAL(ccv.total_value(), 4);
         verify_shard_order(ccv);
-      });
+      }
 
         m = m2;
         transform_counter_updates_to_shards(m, &m0, 0);
 
         ac = get_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
-      counter_cell_view::with_linearized(ac, [&] (counter_cell_view ccv) {
+      {
+        counter_cell_view ccv(ac);
         BOOST_REQUIRE_EQUAL(ccv.total_value(), 14);
         verify_shard_order(ccv);
-      });
+      }
 
         ac = get_static_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
-      counter_cell_view::with_linearized(ac, [&] (counter_cell_view ccv) {
+      {
+        counter_cell_view ccv(ac);
         BOOST_REQUIRE_EQUAL(ccv.total_value(), 12);
         verify_shard_order(ccv);
-      });
+      }
 
         m = m3;
         transform_counter_updates_to_shards(m, &m0, 0);
@@ -519,14 +533,14 @@ SEASTAR_TEST_CASE(test_sanitize_corrupted_cells) {
             auto c2 = atomic_cell_or_collection(b2.build(0));
 
             // Compare
-         counter_cell_view::with_linearized(c1.as_atomic_cell(cdef), [&] (counter_cell_view cv1) {
-          counter_cell_view::with_linearized(c2.as_atomic_cell(cdef), [&] (counter_cell_view cv2) {
+          {
+            counter_cell_view cv1(c1.as_atomic_cell(cdef));
+            counter_cell_view cv2(c2.as_atomic_cell(cdef));
             BOOST_REQUIRE_EQUAL(cv1, cv2);
             BOOST_REQUIRE_EQUAL(cv1.total_value(), cv2.total_value());
             verify_shard_order(cv1);
             verify_shard_order(cv2);
-          });
-         });
+          }
         }
     });
 }

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -433,12 +433,12 @@ static bytes make_payload(const schema& schema, size_t size, const partition_key
     return std::move(buf_os).detach();
 }
 
-static bool validate_payload(const schema& schema, data::value_view payload_view, const partition_key& pk, const clustering_key* const ck) {
-    auto istream = fragmented_memory_input_stream(payload_view.begin(), payload_view.size_bytes());
+static bool validate_payload(const schema& schema, atomic_cell_value_view payload_view, const partition_key& pk, const clustering_key* const ck) {
+    auto istream = fragmented_memory_input_stream(payload_view.as_fragment_range().begin(), payload_view.size());
 
     auto head = ser::deserialize(istream, boost::type<blob_header>{});
 
-    const size_t actual_size = payload_view.size_bytes();
+    const size_t actual_size = payload_view.size();
 
     if (head.size != actual_size) {
         testlog.error("Validating payload for pk={}, ck={} failed, sizes differ: stored={}, actual={}", pk, seastar::lazy_deref(ck), head.size,

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -212,10 +212,11 @@ composite cell_name(const schema& s, const clustering_key& ck, const column_defi
     if (s.is_dense()) {
         return composite::serialize_value(ck.components(s), s.is_compound());
     } else {
-        const bytes_view column_name = col.name();
+        const managed_bytes column_name = col.name();
+        const managed_bytes_view column_name_view = column_name;
         return composite::serialize_value(boost::range::join(
                 boost::make_iterator_range(ck.begin(s), ck.end(s)),
-                boost::make_iterator_range(&column_name, &column_name + 1)),
+                boost::make_iterator_range(&column_name_view, &column_name_view + 1)),
             s.is_compound());
     }
 }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1904,6 +1904,9 @@ SEASTAR_TEST_CASE(test_continuity_merging) {
 class measuring_allocator final : public allocation_strategy {
     size_t _allocated_bytes;
 public:
+    measuring_allocator() {
+        _preferred_max_contiguous_allocation = standard_allocator().preferred_max_contiguous_allocation();
+    }
     virtual void* alloc(migrate_fn mf, size_t size, size_t alignment) override {
         _allocated_bytes += size;
         return standard_allocator().alloc(mf, size, alignment);

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1902,7 +1902,7 @@ SEASTAR_TEST_CASE(test_continuity_merging) {
 }
 
 class measuring_allocator final : public allocation_strategy {
-    size_t _allocated_bytes;
+    size_t _allocated_bytes = 0;
 public:
     measuring_allocator() {
         _preferred_max_contiguous_allocation = standard_allocator().preferred_max_contiguous_allocation();

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1992,7 +1992,6 @@ SEASTAR_THREAD_TEST_CASE(test_cell_external_memory_usage) {
             auto before = alloc.allocated_bytes();
             auto ac = atomic_cell_or_collection(atomic_cell::make_live(*dt, 1, bv));
             auto after = alloc.allocated_bytes();
-            BOOST_CHECK_GE(ac.external_memory_usage(*dt), bv.size());
             BOOST_CHECK_EQUAL(ac.external_memory_usage(*dt), after - before);
         });
     };

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -1566,14 +1566,15 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_counters_read) {
         assertions.push_back([&, timestamp, value, clock] (const column_definition& def,
                                                            const atomic_cell_or_collection* cell) {
             BOOST_REQUIRE(def.is_counter());
-            counter_cell_view::with_linearized(cell->as_atomic_cell(def), [&] (counter_cell_view cv) {
+            {
+                counter_cell_view cv(cell->as_atomic_cell(def));
                 BOOST_REQUIRE_EQUAL(timestamp, cv.timestamp());
                 BOOST_REQUIRE_EQUAL(1, cv.shard_count());
                 auto shard = cv.get_shard(HOST_ID);
                 BOOST_REQUIRE(shard);
                 BOOST_REQUIRE_EQUAL(value, shard->value());
                 BOOST_REQUIRE_EQUAL(clock, shard->logical_clock());
-            });
+            }
         });
 
         return assertions;

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1155,8 +1155,8 @@ SEASTAR_TEST_CASE(compact) {
                         auto &cells = row.cells();
                         auto& cdef1 = *s->get_column_definition("age");
                         auto& cdef2 = *s->get_column_definition("height");
-                        BOOST_REQUIRE(cells.cell_at(cdef1.id).as_atomic_cell(cdef1).value() == bytes({0,0,0,40}));
-                        BOOST_REQUIRE(cells.cell_at(cdef2.id).as_atomic_cell(cdef2).value() == bytes({0,0,0,(int8_t)170}));
+                        BOOST_REQUIRE(cells.cell_at(cdef1.id).as_atomic_cell(cdef1).value() == managed_bytes({0,0,0,40}));
+                        BOOST_REQUIRE(cells.cell_at(cdef2.id).as_atomic_cell(cdef2).value() == managed_bytes({0,0,0,(int8_t)170}));
                         return read_mutation_from_flat_mutation_reader(*reader, db::no_timeout);
                     }).then([reader, s] (mutation_opt m) {
                         BOOST_REQUIRE(m);
@@ -1169,8 +1169,8 @@ SEASTAR_TEST_CASE(compact) {
                         auto &cells = row.cells();
                         auto& cdef1 = *s->get_column_definition("age");
                         auto& cdef2 = *s->get_column_definition("height");
-                        BOOST_REQUIRE(cells.cell_at(cdef1.id).as_atomic_cell(cdef1).value() == bytes({0,0,0,20}));
-                        BOOST_REQUIRE(cells.cell_at(cdef2.id).as_atomic_cell(cdef2).value() == bytes({0,0,0,(int8_t)180}));
+                        BOOST_REQUIRE(cells.cell_at(cdef1.id).as_atomic_cell(cdef1).value() == managed_bytes({0,0,0,20}));
+                        BOOST_REQUIRE(cells.cell_at(cdef2.id).as_atomic_cell(cdef2).value() == managed_bytes({0,0,0,(int8_t)180}));
                         return read_mutation_from_flat_mutation_reader(*reader, db::no_timeout);
                     }).then([reader, s] (mutation_opt m) {
                         BOOST_REQUIRE(m);
@@ -1183,7 +1183,7 @@ SEASTAR_TEST_CASE(compact) {
                         auto &cells = row.cells();
                         auto& cdef1 = *s->get_column_definition("age");
                         auto& cdef2 = *s->get_column_definition("height");
-                        BOOST_REQUIRE(cells.cell_at(cdef1.id).as_atomic_cell(cdef1).value() == bytes({0,0,0,20}));
+                        BOOST_REQUIRE(cells.cell_at(cdef1.id).as_atomic_cell(cdef1).value() == managed_bytes({0,0,0,20}));
                         BOOST_REQUIRE(cells.find_cell(cdef2.id) == nullptr);
                         return read_mutation_from_flat_mutation_reader(*reader, db::no_timeout);
                     }).then([reader, s] (mutation_opt m) {
@@ -2449,7 +2449,7 @@ SEASTAR_TEST_CASE(check_multi_schema) {
                     auto& cells = row.cells();
                     BOOST_REQUIRE_EQUAL(cells.size(), 1);
                     auto& cdef = *s->get_column_definition("e");
-                    BOOST_REQUIRE_EQUAL(cells.cell_at(cdef.id).as_atomic_cell(cdef).value(), int32_type->decompose(5));
+                    BOOST_REQUIRE_EQUAL(cells.cell_at(cdef.id).as_atomic_cell(cdef).value(), managed_bytes(int32_type->decompose(5)));
                     return (*reader)(db::no_timeout);
                 }).then([reader, s] (mutation_fragment_opt m) {
                     BOOST_REQUIRE(!m);
@@ -2759,7 +2759,7 @@ SEASTAR_TEST_CASE(test_counter_read) {
             BOOST_REQUIRE(mfopt->is_clustering_row());
             const clustering_row* cr = &mfopt->as_clustering_row();
             cr->cells().for_each_cell([&] (column_id id, const atomic_cell_or_collection& c) {
-              counter_cell_view::with_linearized(c.as_atomic_cell(s->regular_column_at(id)), [&] (counter_cell_view ccv) {
+                counter_cell_view ccv(c.as_atomic_cell(s->regular_column_at(id)));
                 auto& col = s->column_at(column_kind::regular_column, id);
                 if (col.name_as_text() == "c1") {
                     BOOST_REQUIRE_EQUAL(ccv.total_value(), 13);
@@ -2780,7 +2780,6 @@ SEASTAR_TEST_CASE(test_counter_read) {
                 } else {
                     BOOST_FAIL(format("Unexpected column \'{}\'", col.name_as_text()));
                 }
-              });
             });
 
             mfopt = reader(db::no_timeout).get0();
@@ -4957,12 +4956,11 @@ SEASTAR_TEST_CASE(test_wrong_counter_shard_order) {
                 size_t n = 0;
                 row.cells().for_each_cell([&] (column_id id, const atomic_cell_or_collection& ac_o_c) {
                     auto acv = ac_o_c.as_atomic_cell(s->regular_column_at(id));
-                  counter_cell_view::with_linearized(acv, [&] (counter_cell_view ccv) {
+                    counter_cell_view ccv(acv);
                     counter_shard_view::less_compare_by_id cmp;
                     BOOST_REQUIRE_MESSAGE(boost::algorithm::is_sorted(ccv.shards(), cmp), ccv << " is expected to be sorted");
                     BOOST_REQUIRE_EQUAL(ccv.total_value(), expected_value);
                     n++;
-                  });
                 });
                 BOOST_REQUIRE_EQUAL(n, 5);
             };

--- a/types.hh
+++ b/types.hh
@@ -503,6 +503,7 @@ public:
         : _name(name), _value_length_if_fixed(std::move(value_length_if_fixed)), _kind(k) {}
     virtual ~abstract_type() {}
     bool less(bytes_view v1, bytes_view v2) const { return compare(v1, v2) < 0; }
+    bool less(managed_bytes_view v1, managed_bytes_view v2) const { return compare(v1, v2) < 0; }
     // returns a callable that can be called with two byte_views, and calls this->less() on them.
     serialized_compare as_less_comparator() const ;
     serialized_tri_compare as_tri_comparator() const ;
@@ -834,6 +835,9 @@ class serialized_compare {
 public:
     serialized_compare(data_type type) : _type(type) {}
     bool operator()(const bytes& v1, const bytes& v2) const {
+        return _type->less(v1, v2);
+    }
+    bool operator()(const managed_bytes& v1, const managed_bytes& v2) const {
         return _type->less(v1, v2);
     }
 };

--- a/types.hh
+++ b/types.hh
@@ -1142,8 +1142,11 @@ T read_simple(managed_bytes_view& v) {
     if (v.size() < sizeof(T)) {
         throw_with_backtrace<marshal_exception>(format("read_simple - not enough bytes (expected {:d}, got {:d})", sizeof(T), v.size()));
     }
-    // FIXME: implement
-    return T();
+    T x;
+    // FIXME: improve
+    std::copy_n(v.begin(), sizeof(T), reinterpret_cast<bytes::value_type*>(&x));
+    v.remove_prefix(sizeof(T));
+    return net::ntoh(x);
 }
 
 template<typename T>
@@ -1160,8 +1163,10 @@ T read_simple_exactly(managed_bytes_view v) {
     if (v.size() != sizeof(T)) {
         throw_with_backtrace<marshal_exception>(format("read_simple_exactly - size mismatch (expected {:d}, got {:d})", sizeof(T), v.size()));
     }
-    // FIXME: implement
-    return T();
+    T x;
+    // FIXME: improve
+    std::copy_n(v.begin(), sizeof(T), reinterpret_cast<bytes::value_type*>(&x));
+    return net::ntoh(x);
 }
 
 inline
@@ -1181,8 +1186,9 @@ read_simple_bytes(managed_bytes_view& v, size_t n) {
     if (v.size() < n) {
         throw_with_backtrace<marshal_exception>(format("read_simple_bytes - not enough bytes (requested {:d}, got {:d})", n, v.size()));
     }
-    // FIXME: implement
-    return managed_bytes_view();
+    auto prefix = v.substr(0, n);
+    v.remove_prefix(n);
+    return prefix;
 }
 
 template<typename T>

--- a/utils/managed_bytes.cc
+++ b/utils/managed_bytes.cc
@@ -129,3 +129,16 @@ int compare_unsigned(const managed_bytes_view v1, const managed_bytes_view v2) {
 std::ostream& operator<<(std::ostream& os, const managed_bytes& b) {
     return os << managed_bytes_view(b);
 }
+
+sstring to_hex(managed_bytes_view b) {
+    static char digits[] = "0123456789abcdef";
+    sstring out = uninitialized_string(b.size() * 2);
+    size_t i = 0;
+    for (auto ch : b) {
+        uint8_t x = ch;
+        out[2*i] = digits[x >> 4];
+        out[2*i+1] = digits[x & 0xf];
+        ++i;
+    }
+    return out;
+}

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -680,6 +680,9 @@ public:
         do_linearize_pure(ret.begin());
         return ret;
     }
+    bytes linearize() const {
+        return to_bytes();
+    }
     bool operator==(const managed_bytes_basic_view& x) const;
     bool operator!=(const managed_bytes_basic_view& x) const {
         return !operator==(x);

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -112,19 +112,27 @@ private:
 
 private:
     void move_to_next_fragment() {
-        if (!_next_fragment) {
-            return;
-        }
-        _current_begin = _next_fragment->data;
-        _current_end = _next_fragment->data + _next_fragment->frag_size;
-        _next_fragment = _next_fragment->next;
+        do {
+            if (!_next_fragment) {
+                _current_begin = nullptr;
+                _current_end = nullptr;
+                break;
+            }
+            _current_begin = _next_fragment->data;
+            _current_end = _next_fragment->data + _next_fragment->frag_size;
+            _next_fragment = _next_fragment->next;
+        } while (_current_begin == _current_end);
     }
 
     managed_bytes_iterator(pointer current_begin, pointer current_end, blob_storage* next) noexcept
         : _current_begin(current_begin)
         , _current_end(current_end)
         , _next_fragment(next)
-    { }
+    {
+        if (_current_begin == _current_end) {
+            move_to_next_fragment();
+        }
+    }
 
 public:
     managed_bytes_iterator() = default;
@@ -167,7 +175,7 @@ public:
     }
 
     bool operator==(const managed_bytes_iterator& o) const {
-        return _current_begin == o._current_begin && _current_end == o._current_end && _next_fragment == o._next_fragment;
+        return _current_begin == o._current_begin;
     }
 };
 

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -850,8 +850,6 @@ bool managed_bytes_basic_view<is_mutable>::operator==(const managed_bytes_basic_
         it1.remove_prefix(n);
         it2.remove_prefix(n);
     }
-    assert(it1 == rv1.end());
-    assert(it2 == rv2.end());
     return true;
 }
 

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -852,6 +852,7 @@ inline std::ostream& operator<<(std::ostream& os, const managed_bytes_basic_view
     return os;
 }
 
+sstring to_hex(managed_bytes_view b);
 bytes to_bytes(const managed_bytes& b);
 bytes to_bytes(managed_bytes_view v);
 int compare_unsigned(const managed_bytes_view v1, const managed_bytes_view v2);


### PR DESCRIPTION
I have been working lately on making the IMR hackathon changes work.
I have corrected the tests which didn't compile and ironed out a couple of bugs introduced by the transition.

Some tests are still failing:
```
test/boost/mutation_reader_test.cc(2556): fatal error: in "test_multishard_combining_reader_non_strictly_monotonic_positions": critical check mf.mutation_fragment_kind() == mutation_fragment::kind::clustering_row has failed [range tombstone != clustering row]

test/boost/sstable_datafile_test.cc(5700): fatal error: in "sstable_run_based_compaction_test": critical check *closed_sstables_tracker == old_sstables.front()->generation() has failed

In lwt_test:
-       "message" : "exceptions::invalid_request_exception (Non-frozen user types or collections are not allowed inside collections: list<set<int>>)",
+       "message" : "exceptions::invalid_request_exception (Non-frozen user types or collections are not allowed inside collections: set<map<int, int>>)",
```
And cql_query_test is missing a chunk of expected output.

I'm still investigating those. I suspect they are connected.

This PR is a heads-up. I will probably want to rewrite history after I hunt down the remaining bugs.
