### PR TITLE
view: Add DROP VIEW support

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -386,6 +386,7 @@ cqlStatement returns [std::unique_ptr<raw::parsed_statement> stmt]
     | st48=pruneMaterializedViewStatement  { $stmt = std::move(st48); }
     | st49=describeStatement           { $stmt = std::move(st49); }
     | st50=listEffectiveServiceLevelStatement { $stmt = std::move(st50); }
+    | st51=dropNonMaterializedViewStatement { $stmt = std::move(st51); }
     ;
 
 /*
@@ -1114,6 +1115,15 @@ dropViewStatement returns [std::unique_ptr<drop_view_statement> stmt]
     @init { bool if_exists = false; }
     : K_DROP K_MATERIALIZED K_VIEW (K_IF K_EXISTS { if_exists = true; } )? cf=columnFamilyName
       { $stmt = std::make_unique<drop_view_statement>(cf, if_exists); }
+    ;
+
+/**
+ * DROP VIEW [IF EXISTS] <view_name>
+ */
+dropNonMaterializedViewStatement returns [std::unique_ptr<drop_non_materialized_view_statement> stmt]
+    @init { bool if_exists = false; }
+    : K_DROP K_VIEW (K_IF K_EXISTS { if_exists = true; } )? cf=columnFamilyName
+      { $stmt = std::make_unique<drop_non_materialized_view_statement>(cf, if_exists); }
     ;
 
 /**

--- a/cql3/statements/drop_view_statement.cc
+++ b/cql3/statements/drop_view_statement.cc
@@ -69,6 +69,54 @@ drop_view_statement::prepare(data_dictionary::database db, cql_stats& stats) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_view_statement>(*this));
 }
 
+drop_non_materialized_view_statement::drop_non_materialized_view_statement(cf_name view_name, bool if_exists)
+    : schema_altering_statement{std::move(view_name), &timeout_config::truncate_timeout}
+    , _if_exists{if_exists}
+{
+}
+
+future<> drop_non_materialized_view_statement::check_access(query_processor& qp, const service::client_state& state) const
+{
+    try {
+        const data_dictionary::database db = qp.db();
+        auto&& s = db.find_schema(keyspace(), column_family());
+        if (s->is_view()) {
+            return state.has_column_family_access(keyspace(), s->view_info()->base_name(), auth::permission::ALTER);
+        }
+    } catch (const data_dictionary::no_such_column_family& e) {
+        // Will be validated afterwards.
+    }
+    return make_ready_future<>();
+}
+
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
+drop_non_materialized_view_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
+    ::shared_ptr<cql_transport::event::schema_change> ret;
+    std::vector<mutation> m;
+
+    try {
+        m = co_await service::prepare_non_materialized_view_drop_announcement(qp.proxy(), keyspace(), column_family(), ts);
+
+        using namespace cql_transport;
+        ret = ::make_shared<event::schema_change>(
+            event::schema_change::change_type::DROPPED,
+            event::schema_change::target_type::TABLE,
+            keyspace(),
+            column_family());
+    } catch (const exceptions::configuration_exception& e) {
+        if (!_if_exists) {
+            co_return coroutine::exception(std::current_exception());
+        }
+    }
+
+    co_return std::make_tuple(std::move(ret), std::move(m), std::vector<sstring>());
+}
+
+std::unique_ptr<cql3::statements::prepared_statement>
+drop_non_materialized_view_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+    return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_non_materialized_view_statement>(*this));
+}
+
 }
 
 }

--- a/cql3/statements/drop_view_statement.hh
+++ b/cql3/statements/drop_view_statement.hh
@@ -37,5 +37,19 @@ public:
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 };
 
+/** A <code>DROP VIEW</code> parsed from a CQL query statement. */
+class drop_non_materialized_view_statement : public schema_altering_statement {
+private:
+    bool _if_exists;
+public:
+    drop_non_materialized_view_statement(cf_name view_name, bool if_exists);
+
+    virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
+
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+};
+
 }
 }

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -303,6 +303,7 @@ std::vector<mutation> make_create_view_mutations(lw_shared_ptr<keyspace_metadata
 std::vector<mutation> make_update_view_mutations(lw_shared_ptr<keyspace_metadata> keyspace, view_ptr old_view, view_ptr new_view, api::timestamp_type timestamp, bool include_base);
 
 std::vector<mutation> make_drop_view_mutations(lw_shared_ptr<keyspace_metadata> keyspace, view_ptr view, api::timestamp_type timestamp);
+std::vector<mutation> make_drop_non_materialized_view_mutations(lw_shared_ptr<keyspace_metadata> keyspace, view_ptr view, api::timestamp_type timestamp);
 
 void check_no_legacy_secondary_index_mv_schema(replica::database& db, const view_ptr& v, schema_ptr base_schema);
 

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -246,5 +246,6 @@ future<std::vector<mutation>> prepare_new_view_announcement(storage_proxy& sp, v
 future<std::vector<mutation>> prepare_view_update_announcement(storage_proxy& sp, view_ptr view, api::timestamp_type ts);
 
 future<std::vector<mutation>> prepare_view_drop_announcement(storage_proxy& sp, const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts);
+future<std::vector<mutation>> prepare_non_materialized_view_drop_announcement(storage_proxy& sp, const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts);
 
 }


### PR DESCRIPTION
This adds basic drop view support. Currently, it drops the materialized view only. It is not wired up with the non materialized view yet.

E.g.,

DROP VIEW ks2.mv2 ;

works now.
